### PR TITLE
readme: enable copy-paste instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ seastar as a dependency.
 
 ```bash
 git submodule update --init --recursive
-./install-deps.sh
+sudo ./install-deps.sh
 cmake .
 make
 ./main


### PR DESCRIPTION
Most people will simply copy-paste the instructions
from the website and expect it to work. Debugging CMake output 
is tedious and if one doesn't have all the dependencies installed.